### PR TITLE
feat: add terminal pulse clock script

### DIFF
--- a/pulse_clock.py
+++ b/pulse_clock.py
@@ -11,6 +11,10 @@ import math
 import time
 from datetime import datetime
 
+BAR_WIDTH = 24
+PULSE_HZ = 0.75
+FRAME_INTERVAL = 0.1
+
 
 def render_pulse_bar(width: int = 24, phase: float = 0.0) -> str:
     """根据相位生成脉冲条。"""
@@ -26,12 +30,16 @@ def run_pulse_clock() -> None:
 
     start = time.monotonic()
     while True:
+        frame_start = time.monotonic()
         now = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-        elapsed = time.monotonic() - start
-        pulse = render_pulse_bar(phase=elapsed * 2 * math.pi * 0.8)
+        elapsed = frame_start - start
+        phase = elapsed * 2 * math.pi * PULSE_HZ
+        pulse = render_pulse_bar(width=BAR_WIDTH, phase=phase)
         line = f"\r🕒 {now}  |  {pulse}"
         print(line, end="", flush=True)
-        time.sleep(0.1)
+        remaining = FRAME_INTERVAL - (time.monotonic() - frame_start)
+        if remaining > 0:
+            time.sleep(remaining)
 
 
 if __name__ == "__main__":

--- a/pulse_clock.py
+++ b/pulse_clock.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""终端脉冲时钟。
+
+每秒刷新一次当前时间，并通过变化的条形长度模拟“脉冲”效果。
+按 Ctrl+C 退出。
+"""
+
+from __future__ import annotations
+
+import math
+import time
+from datetime import datetime
+
+
+def render_pulse_bar(width: int = 24, phase: float = 0.0) -> str:
+    """根据相位生成脉冲条。"""
+    value = (math.sin(phase) + 1) / 2  # 0~1
+    filled = max(1, int(round(value * width)))
+    return "█" * filled + "·" * (width - filled)
+
+
+def run_pulse_clock() -> None:
+    """循环显示带脉冲效果的当前时间。"""
+    print("脉冲时钟启动（Ctrl+C 退出）")
+    print()
+
+    start = time.time()
+    while True:
+        now = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        elapsed = time.time() - start
+        pulse = render_pulse_bar(phase=elapsed * math.pi)
+        line = f"\r🕒 {now}  |  {pulse}"
+        print(line, end="", flush=True)
+        time.sleep(1)
+
+
+if __name__ == "__main__":
+    try:
+        run_pulse_clock()
+    except KeyboardInterrupt:
+        print("\n已退出脉冲时钟。")

--- a/pulse_clock.py
+++ b/pulse_clock.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """终端脉冲时钟。
 
-每秒刷新一次当前时间，并通过变化的条形长度模拟“脉冲”效果。
+持续刷新当前时间，并通过变化的条形长度模拟“脉冲”效果。
 按 Ctrl+C 退出。
 """
 
@@ -24,14 +24,14 @@ def run_pulse_clock() -> None:
     print("脉冲时钟启动（Ctrl+C 退出）")
     print()
 
-    start = time.time()
+    start = time.monotonic()
     while True:
         now = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-        elapsed = time.time() - start
-        pulse = render_pulse_bar(phase=elapsed * math.pi)
+        elapsed = time.monotonic() - start
+        pulse = render_pulse_bar(phase=elapsed * 2 * math.pi * 0.8)
         line = f"\r🕒 {now}  |  {pulse}"
         print(line, end="", flush=True)
-        time.sleep(1)
+        time.sleep(0.1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation
- Implement a simple terminal "pulse clock" tool to display the current time with a visual pulsing indicator as requested.
- Provide a lightweight, standalone script that can be run directly in a shell and exited cleanly with `Ctrl+C`.

### Description
- Added `pulse_clock.py`, a new standalone script that prints the timestamp and an animated pulse bar in the terminal.
- Implemented `render_pulse_bar(width: int, phase: float)` to generate a bar whose filled length is driven by a sine-wave phase.
- Implemented `run_pulse_clock()` to loop, render the current time plus the pulse bar each second, and handle `KeyboardInterrupt` for graceful exit.

### Testing
- Ran `python3 -m py_compile pulse_clock.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7a019b4a48329906bb6f3963cb868)