### PR TITLE
Add ApocalypseChecklist Ethereum smart contract

### DIFF
--- a/ApocalypseChecklist.sol
+++ b/ApocalypseChecklist.sol
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/// @title ApocalypseChecklist
+/// @notice 一个娱乐性质的“世界毁灭待办”合约，链上仅做记录与触发事件，不会真的执行现实操作。
+contract ApocalypseChecklist {
+    address public owner;
+    bool public worldEnded;
+
+    event WorldEndDeclared(uint256 timestamp, string message);
+    event ActionTriggered(uint256 indexed actionId, string actionName, uint256 timestamp);
+
+    error NotOwner();
+    error WorldNotEnded();
+    error AlreadyDeclared();
+
+    struct Action {
+        uint256 id;
+        string name;
+        bool done;
+        uint256 doneAt;
+    }
+
+    Action[] private actions;
+
+    constructor() {
+        owner = msg.sender;
+
+        actions.push(Action({id: 1, name: "下载原神", done: false, doneAt: 0}));
+        actions.push(Action({id: 2, name: "删除COD", done: false, doneAt: 0}));
+        actions.push(Action({id: 3, name: "在时代广场大屏幕播放NDX100BEST", done: false, doneAt: 0}));
+    }
+
+    modifier onlyOwner() {
+        if (msg.sender != owner) revert NotOwner();
+        _;
+    }
+
+    /// @notice 宣布“世界毁灭”状态（仅可调用一次）
+    function declareWorldEnd() external onlyOwner {
+        if (worldEnded) revert AlreadyDeclared();
+        worldEnded = true;
+        emit WorldEndDeclared(block.timestamp, "世界毁灭模式已开启");
+    }
+
+    /// @notice 标记某个待办事项已触发（需要先宣布 worldEnded）
+    function triggerAction(uint256 actionId) external onlyOwner {
+        if (!worldEnded) revert WorldNotEnded();
+        require(actionId > 0 && actionId <= actions.length, "Invalid actionId");
+
+        Action storage action = actions[actionId - 1];
+        action.done = true;
+        action.doneAt = block.timestamp;
+
+        emit ActionTriggered(action.id, action.name, block.timestamp);
+    }
+
+    function getAction(uint256 actionId)
+        external
+        view
+        returns (uint256 id, string memory name, bool done, uint256 doneAt)
+    {
+        require(actionId > 0 && actionId <= actions.length, "Invalid actionId");
+        Action memory action = actions[actionId - 1];
+        return (action.id, action.name, action.done, action.doneAt);
+    }
+
+    function getAllActions() external view returns (Action[] memory) {
+        return actions;
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a simple, on-chain, owner-controlled checklist to record a fictional "apocalypse" workflow and the three specified actions for entertainment/logging only.
- Ensure the contract cannot perform real-world effects and only emits events and stores timestamps for external monitoring.

### Description
- Added `ApocalypseChecklist.sol`, a Solidity ^0.8.20 contract that defines an `Action` struct and an array of actions seeded in the constructor with the three requested items (`下载原神`, `删除COD`, `在时代广场大屏幕播放NDX100BEST`).
- Implemented owner-only control with an `owner` field and `onlyOwner` modifier, plus a `worldEnded` boolean to gate actions.
- Exposed `declareWorldEnd()` to flip the apocalypse mode once and emit `WorldEndDeclared`, and `triggerAction(actionId)` to mark actions done and emit `ActionTriggered` with timestamps.
- Provided read interfaces `getAction(actionId)` and `getAllActions()` and added custom errors (`NotOwner`, `WorldNotEnded`, `AlreadyDeclared`).

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cbe428dd388329b9ab18ab25d0ff41)